### PR TITLE
Query interface

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,6 +9,10 @@ class Order < ApplicationRecord
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: pay_types.keys
 
+  scope :by_date, -> (from = Time.current.beginning_of_day, to = Time.current.end_of_day) {
+    where(created_at: from..to)
+  }
+
   def add_line_items_from_cart(cart)
     cart.line_items.each do |item|
       item.cart_id = nil

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,7 +26,9 @@ class Product < ApplicationRecord
   before_validation :set_title, unless: :title?
 
   before_validation :set_discount_price, unless: :discount_price?
-  
+
+  scope :enabled, -> { where(enabled: true) }
+
   private
   # def ensure_not_referenced_by_any_line_item
   #   unless line_items.empty?


### PR DESCRIPTION
Make a scope for all the enabled products
Add another scope in order which accept two dates and return orders placed between those dates
Order.by_date(from, to)
Order.by_date : without arguments, should return order for the current day
user.orders.by_date should work and it should return orders placed by user between given dates. Check the query difference in this one and the above one
    Build queries for following

     		- Get All products which are present in atleast one line_item
     		Ans> Product.joins(:line_items).distinct

     		- Get array of product titles which are present in atleast one line item
     		Ans>  Product.joins(:line_items).distinct.pluck(:title)

